### PR TITLE
Adjust the TypeScript options in Rollup to set rootDir and outDir

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -72,7 +72,9 @@ export default {
       tsconfigOverride: {
         compilerOptions: {
           declaration: true,
-          declarationDir: 'dist'
+          declarationDir: 'dist',
+          rootDir: 'src',
+          outDir: 'dist',
         }
       }
     }),


### PR DESCRIPTION
Hello,

Proposed fix for issue #51 

Best regards.