### PR TITLE
Fix: use Object.is() to prevent infinite loop when value is NaN (#11)

### DIFF
--- a/src/OnChange.test.tsx
+++ b/src/OnChange.test.tsx
@@ -192,7 +192,8 @@ describe('OnChange', () => {
     // Spy should be called exactly once for the initial NaN value,
     // NOT in an infinite loop (and not zero times, which would mask regressions)
     expect(spy).toHaveBeenCalledTimes(1)
-    expect(spy).toHaveBeenCalledWith(NaN, undefined)
+    // Previous value is empty string because final-form initializes fields with ""
+    expect(spy).toHaveBeenCalledWith(NaN, "")
   })
 
   it('should not call listener on re-renders when value has not changed (#7)', () => {

--- a/src/OnChange.test.tsx
+++ b/src/OnChange.test.tsx
@@ -189,9 +189,10 @@ describe('OnChange', () => {
       render(<Wrapper />)
     }).not.toThrow()
 
-    // Spy should be called at most once for the initial NaN value,
-    // NOT in an infinite loop
-    expect(spy.mock.calls.length).toBeLessThanOrEqual(1)
+    // Spy should be called exactly once for the initial NaN value,
+    // NOT in an infinite loop (and not zero times, which would mask regressions)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith(NaN, undefined)
   })
 
   it('should not call listener on re-renders when value has not changed (#7)', () => {

--- a/src/OnChange.test.tsx
+++ b/src/OnChange.test.tsx
@@ -192,6 +192,8 @@ describe('OnChange', () => {
     // Spy should be called at most once for the initial NaN value,
     // NOT in an infinite loop
     expect(spy.mock.calls.length).toBeLessThanOrEqual(1)
+  })
+
   it('should not call listener on re-renders when value has not changed (#7)', () => {
     // https://github.com/final-form/react-final-form-listeners/issues/7
     // OnChange should NOT fire on re-renders when the value hasn't changed.

--- a/src/OnChange.tsx
+++ b/src/OnChange.tsx
@@ -23,7 +23,7 @@ const OnChangeState: React.FC<Props> = ({ children, input }) => {
       return
     }
 
-    if (input.value !== previousValueRef.current) {
+    if (!Object.is(input.value, previousValueRef.current)) {
       children(input.value, previousValueRef.current)
       previousValueRef.current = input.value
     }


### PR DESCRIPTION
## Problem

https://github.com/final-form/react-final-form-listeners/issues/11

`NaN !== NaN` is always `true` in JavaScript. The `OnChangeState` component used `!==` to compare the current and previous values. When the watched field value is `NaN`:

1. `NaN !== NaN` → `true` → callback fires
2. If the callback triggers a re-render (e.g. `form.change('other', ...)`)
3. `OnChangeState` re-renders, `useLayoutEffect` runs
4. `NaN !== NaN` → `true` again → callback fires again
5. **Infinite loop** 💥

## Fix

Replace `!==` with `Object.is()` which correctly treats `NaN` as equal to itself:

```typescript
// Before (buggy):
if (input.value !== previousValueRef.current) {

// After (fixed):
if (!Object.is(input.value, previousValueRef.current)) {
```

`Object.is(NaN, NaN) === true`, so NaN values are correctly treated as unchanged.

## Test

Added a regression test that demonstrates the infinite loop with the old code and verifies it's fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change-detection to use robust equality checks so updates no longer trigger repeated callbacks for NaN or -0/0 edge cases, preventing potential infinite update loops and spurious re-invocations.

* **Tests**
  * Added regression test coverage for NaN-related edge cases to ensure initial render and listener behavior are stable and callbacks fire at most once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->