### PR TITLE
chore: release v3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-final-form-listeners",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A collection of components to listen to 🏁 React Final Form fields",
   "main": "dist/react-final-form-listeners.cjs.js",
   "jsnext:main": "dist/react-final-form-listeners.es.js",


### PR DESCRIPTION
## Release v3.0.1

Bump version to 3.0.1 in preparation for release.

### Changes since v3.0.0
- Fix use `Object.is()` to prevent infinite loop when watched value is `NaN`